### PR TITLE
Combined dependency updates (2023-07-24)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.3</version>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <junit.platform.version>1.0.0</junit.platform.version>
         <selenium-jupiter.version>4.3.6</selenium-jupiter.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <junit-jupiter-engine.version>5.9.3</junit-jupiter-engine.version>
+        <junit-jupiter-engine.version>5.10.0</junit-jupiter-engine.version>
         <junit-jupiter-params.version>5.9.3</junit-jupiter-params.version>
         <junit.version>4.13.2</junit.version>
         <webdrivermanager.version>5.4.1</webdrivermanager.version>


### PR DESCRIPTION
Includes these updates:
- [Bump org.junit.jupiter:junit-jupiter-api from 5.9.3 to 5.10.0](https://github.com/giis-uniovi/retorch-st-fullteaching/pull/3)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.9.3 to 5.10.0](https://github.com/giis-uniovi/retorch-st-fullteaching/pull/2)

Does not include these updates because of merge conflicts:
- [Bump org.junit.jupiter:junit-jupiter-params from 5.9.3 to 5.10.0](https://github.com/giis-uniovi/retorch-st-fullteaching/pull/1)