### PR TITLE
Added the pulling commands for the browsers and the videorecorders related #5

### DIFF
--- a/retorchfiles/scripts/coilifecycles/coi-setup.sh
+++ b/retorchfiles/scripts/coilifecycles/coi-setup.sh
@@ -15,7 +15,7 @@ find /opt/selenoid/logs/ | wc -l
 mkdir -p "./src/retorchcostestimationdata/exec$BUILD_NUMBER"
 mkdir -p "./artifacts"
 echo "Pulling the Docker Images required by Selenoid (if are not pulled)"
-docker pull selenoid/vnc_chrome:94.0
+docker pull selenoid/vnc_chrome:116.0
 docker pull selenoid/video-recorder:latest-release
 echo "Pulling the Docker Images requirede by the Test suite"
 docker pull eexit/mirror-http-server

--- a/retorchfiles/scripts/coilifecycles/coi-setup.sh
+++ b/retorchfiles/scripts/coilifecycles/coi-setup.sh
@@ -14,7 +14,9 @@ echo 'Remove older logs (7days)! The number of logs prior remove : '
 find /opt/selenoid/logs/ | wc -l
 mkdir -p "./src/retorchcostestimationdata/exec$BUILD_NUMBER"
 mkdir -p "./artifacts"
-
+echo "Pulling the Docker Images required by Selenoid (if are not pulled)"
+docker pull selenoid/vnc_chrome:94.0
+docker pull selenoid/video-recorder:latest-release
 echo "Pulling the Docker Images requirede by the Test suite"
 docker pull eexit/mirror-http-server
 docker pull mysql:5.7.21


### PR DESCRIPTION
Several executions were unstable due to issues with the videorecorder, and the images from the browsers were not available in the CI-agent. Since this is a crucial part of the setup, I have included the pulling command for the two images in the COI-setup script