### PR TITLE
Update GHA from Java 11 to 17 closes #36 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Init jenkins commit status (optional)


### PR DESCRIPTION
Updating to the minimal LTS java version required to compile-execute  the [selenium-jupiter](https://github.com/bonigarcia/selenium-jupiter) library 