### PR TITLE
Removing JUnit dependency that probably causes this bug due to a testng dependency fixes #88

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,6 @@
         
         <junit-jupiter-params.version>5.10.2</junit-jupiter-params.version>
         
-        <junit.version>4.13.2</junit.version>
-        
         <webdrivermanager.version>5.6.3</webdrivermanager.version>
         
         <retorch.version>1.1.0</retorch.version>
@@ -114,12 +112,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.10.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/fullteaching/e2e/no_elastest/utils/Wait.java
+++ b/src/test/java/com/fullteaching/e2e/no_elastest/utils/Wait.java
@@ -1,6 +1,5 @@
 package com.fullteaching.e2e.no_elastest.utils;
 
-import org.junit.Assert;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -26,15 +25,11 @@ public class Wait {
     }
 
     public static void waitForPageLoaded(WebDriver driver) { //13 lines
-        //DO NOT TOUCH THAT!! It's critical for some waiting
         ExpectedCondition<Boolean> expectation = driver1 -> ((JavascriptExecutor) driver1).executeScript("return document.readyState").toString().equals("complete");
-        try {
 
-            WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30));
-            wait.until(expectation);
-        } catch (Throwable error) {
-            Assert.fail("Timeout waiting for Page Load Request to complete.");
-        }
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30));
+
+        wait.until(expectation);
     }
 
 }


### PR DESCRIPTION
[Several users](https://stackoverflow.com/questions/4646014/running-a-single-test-in-maven-no-tests-were-executed) have reported issues with the combination of Selenium and JUnit, attributed to a TestNG dependency. Before  study how/where this dependency is used, which is only present in one class handle an exception, I have removed it along this assert that its not usefull at all.