### PR TITLE
Resolve Test Instability Caused by Delayed Database Response on Course Deletion

### DIFF
--- a/src/test/java/com/fullteaching/e2e/no_elastest/functional/test/teacher/CourseTeacherTest.java
+++ b/src/test/java/com/fullteaching/e2e/no_elastest/functional/test/teacher/CourseTeacherTest.java
@@ -111,7 +111,7 @@ class CourseTeacherTest extends BaseLoggedTest {
         // Create a new course
         String courseTitle = "Test Course_" + System.currentTimeMillis();
         CourseNavigationUtilities.newCourse(user.getDriver(), courseTitle);
-
+        //TO-DO the problem its here
         // Verify the course has been created
         assertTrue(checkIfCourseExists(driver, courseTitle));
 


### PR DESCRIPTION
This pull request addresses and closes issue #122 by enhancing the deleteCourses method. A custom waiter has been introduced that waits for the number of courses will be one less than the initial ones (the deletion was performed successfully).
Also introduces minor fixes in the logging system (use of implicit string concatenation)
