### PR TITLE
Custom set-date method in sessioTest that deals with the flakiness experienced in several executions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,11 +154,11 @@ stage('TEARDOWN-Infrastructure') {
       }// EndStepsTearDownInf
 }// EndStageTearDown
   }// EndStagesPipeline
- post { 
+ post {
       always {
           archiveArtifacts artifacts: 'artifacts/*.csv', onlyIfSuccessful: true
           archiveArtifacts artifacts: 'target/testlogs/**/*.*', onlyIfSuccessful: false
           archiveArtifacts artifacts: 'target/containerlogs/**/*.*', onlyIfSuccessful: false
       }//EndAlways
  }//EndPostActions
-}// EndPipeline 
+}// EndPipeline

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,11 +154,11 @@ stage('TEARDOWN-Infrastructure') {
       }// EndStepsTearDownInf
 }// EndStageTearDown
   }// EndStagesPipeline
- post {
+ post { 
       always {
           archiveArtifacts artifacts: 'artifacts/*.csv', onlyIfSuccessful: true
           archiveArtifacts artifacts: 'target/testlogs/**/*.*', onlyIfSuccessful: false
           archiveArtifacts artifacts: 'target/containerlogs/**/*.*', onlyIfSuccessful: false
       }//EndAlways
  }//EndPostActions
-}// EndPipeline
+}// EndPipeline 


### PR DESCRIPTION
Closes #132 
During certain regressions, the session test failed due to incorrect completion of the date chooser. Now, this action is performed in a more fine-grained way, using the sendKeys() and the JS executor, prior clearing and retrying the input up to three times. If the input is still incorrect, an exception is raised with the specific reason for the failure. This approach prevents the test case from taking up to 6 minutes if the session data is not filled in correctly.