### PR TITLE
Configuring Sonarqube to analyze FullTeaching SUT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,28 @@ jobs:
   build:
     runs-on: ubuntu-latest
     #if: ${{ false }}  # disable for now
-    permissions: 
+    permissions:
       statuses: write
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: pass
+          MYSQL_DATABASE: full_teaching
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
 
       - name: Init jenkins commit status (optional)
@@ -32,5 +45,22 @@ jobs:
              -H "X-GitHub-Api-Version: 2022-11-28" \
              -d "{\"state\":\"pending\", \"context\":\"Jenkins CI\"}"
 
-      - name: Build only, tests run in on-premises Jenkins
+      - name: Compile and test SUT, generate JaCoCo coverage report
+        run: mvn verify -B --no-transfer-progress
+        working-directory: sut
+
+      - name: Save JaCoCo coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacoco-report
+          path: sut/target/site/jacoco/
+          retention-days: 7
+
+      - name: Build E2E test suite
         run: mvn test-compile -U --no-transfer-progress
+
+      - name: SonarCloud analysis
+        uses: SonarSource/sonarqube-scan-action@v8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://github.com/giis-uniovi/retorch-st-fullteaching/actions/workflows/build.yml/badge.svg)](https://github.com/giis-uniovi/retorch-st-fullteaching/actions)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=my%3Aretorch-st-fullteaching&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=my%3Aretorch-st-fullteaching)
 
 # RETORCH FullTeaching End-to-End Test Suite
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.organization=giis
+sonar.projectKey=my:retorch-st-fullteaching
+sonar.projectName=retorch-st-fullteaching
+
+sonar.sources=sut/src/main/java
+sonar.tests=sut/src/test/java
+sonar.java.binaries=sut/target/classes
+sonar.java.test.binaries=sut/target/test-classes
+
+sonar.coverage.jacoco.xmlReportPaths=sut/target/site/jacoco/jacoco.xml
+
+sonar.sourceEncoding=UTF-8
+# Exclude pre-built Angular bundles checked into the repo
+sonar.exclusions=sut/src/main/resources/static/**

--- a/sut/pom.xml
+++ b/sut/pom.xml
@@ -54,6 +54,25 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/sut/src/main/java/com/fullteaching/backend/DatabaseInitializer.java
+++ b/sut/src/main/java/com/fullteaching/backend/DatabaseInitializer.java
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Controller;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 @Controller
@@ -207,19 +209,19 @@ public class DatabaseInitializer implements CommandLineRunner {
         c2.getAttenders().add(user1);
         c2.getAttenders().add(user3);
 
-        Calendar calendar = Calendar.getInstance();
-        int milliSecondsInADay = 86400000;
+        long now = Instant.now().toEpochMilli();
+        long milliSecondsInADay = Duration.ofDays(1).toMillis();
         String defaultDescription = "This is a nice description about this session.";
         //Sample sessions
-        Session s1 = new Session("Session 1: Introduction to Web", defaultDescription, calendar.getTimeInMillis());
+        Session s1 = new Session("Session 1: Introduction to Web", defaultDescription, now);
         s1.setCourse(c1);
-        Session s2 = new Session("Nice examples", defaultDescription, calendar.getTimeInMillis() + milliSecondsInADay);
+        Session s2 = new Session("Nice examples", defaultDescription, now + milliSecondsInADay);
         s2.setCourse(c1);
-        Session s3 = new Session("Project analisys", defaultDescription, calendar.getTimeInMillis() + milliSecondsInADay - 8000000);
+        Session s3 = new Session("Project analisys", defaultDescription, now + milliSecondsInADay - 8000000);
         s3.setCourse(c1);
-        Session s4 = new Session("Session 3: New Web Technologies", defaultDescription, calendar.getTimeInMillis() + 4 * milliSecondsInADay);
+        Session s4 = new Session("Session 3: New Web Technologies", defaultDescription, now + 4 * milliSecondsInADay);
         s4.setCourse(c2);
-        Session s5 = new Session("Session 2: Databse integration", defaultDescription, calendar.getTimeInMillis() + 6 * milliSecondsInADay);
+        Session s5 = new Session("Session 2: Databse integration", defaultDescription, now + 6 * milliSecondsInADay);
         s5.setCourse(c2);
 
         c1.getSessions().add(s1);

--- a/sut/src/main/java/com/fullteaching/backend/DatabaseInitializer.java
+++ b/sut/src/main/java/com/fullteaching/backend/DatabaseInitializer.java
@@ -32,6 +32,11 @@ public class DatabaseInitializer implements CommandLineRunner {
         this.userRepository = userRepo;
         this.courseRepository = courseRepo;
         }
+    private static void linkCommentReply(List<Comment> comments, int parentIdx, int childIdx) {
+        comments.get(parentIdx).getReplies().add(comments.get(childIdx));
+        comments.get(childIdx).setCommentParent(comments.get(parentIdx));
+    }
+
     @Override
     public void run(String... args) {
 
@@ -78,35 +83,23 @@ public class DatabaseInitializer implements CommandLineRunner {
 
         //Recursiveness of comments
         //Entry 1
-        listComments.get(0).getReplies().add(listComments.get(1));
-        listComments.get(1).setCommentParent(listComments.get(0));
-        listComments.get(0).getReplies().add(listComments.get(2));
-        listComments.get(2).setCommentParent(listComments.get(0));
-        listComments.get(4).getReplies().add(listComments.get(5));
-        listComments.get(5).setCommentParent(listComments.get(4));
-        listComments.get(5).getReplies().add(listComments.get(6));
-        listComments.get(6).setCommentParent(listComments.get(5));
+        linkCommentReply(listComments, 0, 1);
+        linkCommentReply(listComments, 0, 2);
+        linkCommentReply(listComments, 4, 5);
+        linkCommentReply(listComments, 5, 6);
         //Entry 2
-        listComments.get(8).getReplies().add(listComments.get(9));
-        listComments.get(9).setCommentParent(listComments.get(8));
+        linkCommentReply(listComments, 8, 9);
         //Entry 3
-        listComments.get(12).getReplies().add(listComments.get(13));
-        listComments.get(13).setCommentParent(listComments.get(12));
-        listComments.get(13).getReplies().add(listComments.get(14));
-        listComments.get(14).setCommentParent(listComments.get(13));
+        linkCommentReply(listComments, 12, 13);
+        linkCommentReply(listComments, 13, 14);
         //Entry 5
-        listComments.get(16).getReplies().add(listComments.get(17));
-        listComments.get(17).setCommentParent(listComments.get(16));
-        listComments.get(17).getReplies().add(listComments.get(18));
-        listComments.get(18).setCommentParent(listComments.get(17));
-        listComments.get(16).getReplies().add(listComments.get(19));
-        listComments.get(19).setCommentParent(listComments.get(16));
+        linkCommentReply(listComments, 16, 17);
+        linkCommentReply(listComments, 17, 18);
+        linkCommentReply(listComments, 16, 19);
         //Entry 7
-        listComments.get(23).getReplies().add(listComments.get(24));
-        listComments.get(24).setCommentParent(listComments.get(23));
+        linkCommentReply(listComments, 23, 24);
         //Entry 8
-        listComments.get(25).getReplies().add(listComments.get(26));
-        listComments.get(26).setCommentParent(listComments.get(25));
+        linkCommentReply(listComments, 25, 26);
 
 
         //Sample entries
@@ -170,11 +163,7 @@ public class DatabaseInitializer implements CommandLineRunner {
 
         //Setting index order in each group of files
         for (FileGroup fgAux : listFileGroups) {
-            int i = 0;
-            for (File fAux : fgAux.getFiles()) {
-                fAux.setIndexOrder(i);
-                i++;
-            }
+            fgAux.updateFileIndexOrder();
         }
 
         listFileGroups.get(0).setFileGroupParent(listFileGroups.get(1));

--- a/sut/src/main/java/com/fullteaching/backend/GlobalExceptionHandler.java
+++ b/sut/src/main/java/com/fullteaching/backend/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.fullteaching.backend;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(NumberFormatException.class)
+    public ResponseEntity<Object> handleNumberFormatException(NumberFormatException e) {
+        log.error("Invalid ID format: {}", e.getMessage());
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/sut/src/main/java/com/fullteaching/backend/IdRef.java
+++ b/sut/src/main/java/com/fullteaching/backend/IdRef.java
@@ -1,0 +1,19 @@
+package com.fullteaching.backend;
+
+/** Captures only the {@code id} field from a nested JSON object (e.g. parent references in DTOs). */
+public class IdRef {
+
+    private long id;
+
+    public IdRef() {
+        // Required by Jackson for deserialization
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/sut/src/main/java/com/fullteaching/backend/comment/AbstractCommentContent.java
+++ b/sut/src/main/java/com/fullteaching/backend/comment/AbstractCommentContent.java
@@ -1,0 +1,35 @@
+package com.fullteaching.backend.comment;
+
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class AbstractCommentContent {
+
+    protected String message;
+    protected String videourl;
+    protected boolean audioonly;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getVideourl() {
+        return videourl;
+    }
+
+    public void setVideourl(String videourl) {
+        this.videourl = videourl;
+    }
+
+    public boolean getAudioonly() {
+        return audioonly;
+    }
+
+    public void setAudioonly(boolean audioonly) {
+        this.audioonly = audioonly;
+    }
+}

--- a/sut/src/main/java/com/fullteaching/backend/comment/Comment.java
+++ b/sut/src/main/java/com/fullteaching/backend/comment/Comment.java
@@ -9,14 +9,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-public class Comment {
+public class Comment extends AbstractCommentContent {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
-    private String videourl;
-    private boolean audioonly;
-    private String message;
     private long date;
     @OneToMany(mappedBy = "commentParent", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JsonManagedReference
@@ -31,11 +28,7 @@ public class Comment {
     }
 
     public Comment(String message, long date, User user) {
-        this.message = message;
-        this.date = date;
-        this.user = user;
-        this.replies = new ArrayList<>();
-        this.commentParent = null;
+        this(message, date, user, null);
     }
 
     public Comment(String message, long date, User user, Comment commentParent) {
@@ -52,30 +45,6 @@ public class Comment {
 
     public void setId(long id) {
         this.id = id;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
-    public String getVideourl() {
-        return videourl;
-    }
-
-    public void setVideourl(String videourl) {
-        this.videourl = videourl;
-    }
-
-    public boolean getAudioonly() {
-        return audioonly;
-    }
-
-    public void setAudioonly(boolean audioonly) {
-        this.audioonly = audioonly;
     }
 
     public long getDate() {

--- a/sut/src/main/java/com/fullteaching/backend/comment/CommentController.java
+++ b/sut/src/main/java/com/fullteaching/backend/comment/CommentController.java
@@ -53,17 +53,8 @@ public class CommentController {
         }
 
 
-        long idEntry = -1;
-        long idCourseDetails = -1;
-        try {
-            idEntry = Long.parseLong(entryId);
-            idCourseDetails = Long.parseLong(courseDetailsId);
-        } catch (NumberFormatException e) {
-            log.error("Entry ID '{}' or CourseDetails ID '{}' are not of type Long", entryId, courseDetailsId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        CourseDetails cd = courseDetailsRepository.findById(idCourseDetails).orElse(null);
+        long idEntry = Long.parseLong(entryId);
+        CourseDetails cd = courseDetailsRepository.findById(Long.parseLong(courseDetailsId)).orElse(null);
         if (cd == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/sut/src/main/java/com/fullteaching/backend/comment/CommentDto.java
+++ b/sut/src/main/java/com/fullteaching/backend/comment/CommentDto.java
@@ -1,63 +1,20 @@
 package com.fullteaching.backend.comment;
 
-public class CommentDto {
+import com.fullteaching.backend.IdRef;
 
-    private String message;
-    private String videourl;
-    private boolean audioonly;
-    private CommentParentRef commentParent;
+public class CommentDto extends AbstractCommentContent {
+
+    private IdRef commentParent;
 
     public CommentDto() {
         // Required by Jackson for deserialization
     }
 
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
-
-    public String getVideourl() {
-        return videourl;
-    }
-
-    public void setVideourl(String videourl) {
-        this.videourl = videourl;
-    }
-
-    public boolean getAudioonly() {
-        return audioonly;
-    }
-
-    public void setAudioonly(boolean audioonly) {
-        this.audioonly = audioonly;
-    }
-
-    public CommentParentRef getCommentParent() {
+    public IdRef getCommentParent() {
         return commentParent;
     }
 
-    public void setCommentParent(CommentParentRef commentParent) {
+    public void setCommentParent(IdRef commentParent) {
         this.commentParent = commentParent;
-    }
-
-    /** Captures only the id from the nested commentParent object in the JSON. */
-    public static class CommentParentRef {
-
-        private long id;
-
-        public CommentParentRef() {
-            // Required by Jackson for deserialization
-        }
-
-        public long getId() {
-            return id;
-        }
-
-        public void setId(long id) {
-            this.id = id;
-        }
     }
 }

--- a/sut/src/main/java/com/fullteaching/backend/course/AbstractCourseData.java
+++ b/sut/src/main/java/com/fullteaching/backend/course/AbstractCourseData.java
@@ -1,0 +1,47 @@
+package com.fullteaching.backend.course;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class AbstractCourseData {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    protected long id;
+    protected String title;
+    protected String image;
+
+    @JsonView(SimpleCourseList.class)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @JsonView(SimpleCourseList.class)
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @JsonView(SimpleCourseList.class)
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public interface SimpleCourseList {
+    }
+}

--- a/sut/src/main/java/com/fullteaching/backend/course/Course.java
+++ b/sut/src/main/java/com/fullteaching/backend/course/Course.java
@@ -10,16 +10,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-public class Course {
+public class Course extends AbstractCourseData {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @JsonView(SimpleCourseList.class)
-    private long id;
-    @JsonView(SimpleCourseList.class)
-    private String title;
-    @JsonView(SimpleCourseList.class)
-    private String image;
     @ManyToOne
     private User teacher;
     @OneToOne(cascade = CascadeType.ALL)
@@ -34,12 +26,7 @@ public class Course {
     }
 
     public Course(String title, String image, User teacher) {
-        this.title = title;
-        this.image = image;
-        this.teacher = teacher;
-        this.courseDetails = null;
-        this.sessions = new HashSet<>();
-        this.attenders = new HashSet<>();
+        this(title, image, teacher, null);
     }
 
     public Course(String title, String image, User teacher, CourseDetails courseDetails) {
@@ -49,30 +36,6 @@ public class Course {
         this.courseDetails = courseDetails;
         this.sessions = new HashSet<>();
         this.attenders = new HashSet<>();
-    }
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getImage() {
-        return image;
-    }
-
-    public void setImage(String image) {
-        this.image = image;
     }
 
     public User getTeacher() {
@@ -107,6 +70,16 @@ public class Course {
         this.sessions = sessions;
     }
 
+    /**
+     * Adds an attender to this course and maintains the bidirectional relationship.
+     * Returns true if the attender was not already present on both sides.
+     */
+    public boolean addAttender(User attender) {
+        boolean addedToCourse = this.attenders.add(attender);
+        boolean addedToUser = attender.getCourses().add(this);
+        return addedToCourse && addedToUser;
+    }
+
     //To make 'user.getCourse().remove(course)' possible
     @Override
     public boolean equals(Object other) {
@@ -124,8 +97,5 @@ public class Course {
     @Override
     public String toString() {
         return "Course[title: \"" + this.title + "\", teacher: \"" + this.teacher.getNickName() + "\", #attenders: " + this.attenders.size() + ", #sessions: " + this.sessions.size() + "]";
-    }
-
-    public interface SimpleCourseList {
     }
 }

--- a/sut/src/main/java/com/fullteaching/backend/course/CourseAttenderService.java
+++ b/sut/src/main/java/com/fullteaching/backend/course/CourseAttenderService.java
@@ -1,0 +1,54 @@
+package com.fullteaching.backend.course;
+
+import com.fullteaching.backend.user.User;
+import com.fullteaching.backend.user.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class CourseAttenderService {
+
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
+    public CourseAttenderService(UserRepository userRepository, CourseRepository courseRepository) {
+        this.userRepository = userRepository;
+        this.courseRepository = courseRepository;
+    }
+
+    /**
+     * Resolves valid emails to registered users, updates the bidirectional Course-User
+     * relationship, saves both sides, and returns categorized result sets.
+     *
+     * @param course           the course to add attenders to
+     * @param validEmails      email addresses already validated as syntactically correct
+     * @param notRegistered    set that will be populated with emails having no matching account
+     * @return result holding newly added and already-added user collections
+     */
+    public AttenderUpdateResult updateAttenders(Course course, Set<String> validEmails,
+                                                Set<String> notRegistered) {
+        Collection<User> possibleAttenders = userRepository.findByNameIn(validEmails);
+        Collection<User> added = new HashSet<>();
+        Collection<User> alreadyAdded = new HashSet<>();
+
+        for (String email : validEmails) {
+            if (possibleAttenders.stream().noneMatch(u -> u.getName().equals(email))) {
+                notRegistered.add(email);
+            }
+        }
+
+        for (User attender : possibleAttenders) {
+            (course.addAttender(attender) ? added : alreadyAdded).add(attender);
+        }
+
+        userRepository.saveAll(possibleAttenders);
+        courseRepository.save(course);
+
+        return new AttenderUpdateResult(added, alreadyAdded);
+    }
+
+    public record AttenderUpdateResult(Collection<User> added, Collection<User> alreadyAdded) {}
+}

--- a/sut/src/main/java/com/fullteaching/backend/course/CourseController.java
+++ b/sut/src/main/java/com/fullteaching/backend/course/CourseController.java
@@ -1,7 +1,7 @@
 package com.fullteaching.backend.course;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import com.fullteaching.backend.course.Course.SimpleCourseList;
+import com.fullteaching.backend.course.AbstractCourseData.SimpleCourseList;
 import com.fullteaching.backend.coursedetails.CourseDetails;
 import com.fullteaching.backend.security.AuthorizationService;
 import com.fullteaching.backend.user.User;
@@ -26,20 +26,22 @@ import java.util.Set;
 public class CourseController {
 
     private static final Logger log = LoggerFactory.getLogger(CourseController.class);
-    private static final String COURSE_ID_NOT_LONG = "Course ID '{}' is not of type Long";
 
     private final CourseRepository courseRepository;
     private final UserRepository userRepository;
     private final ObjectProvider<UserComponent> userProvider;
     private final AuthorizationService authorizationService;
+    private final CourseAttenderService courseAttenderService;
 
     public CourseController(CourseRepository courseRepository, UserRepository userRepository,
                             ObjectProvider<UserComponent> userProvider,
-                            AuthorizationService authorizationService) {
+                            AuthorizationService authorizationService,
+                            CourseAttenderService courseAttenderService) {
         this.courseRepository = courseRepository;
         this.userRepository = userRepository;
         this.userProvider = userProvider;
         this.authorizationService = authorizationService;
+        this.courseAttenderService = courseAttenderService;
     }
 
     @JsonView(SimpleCourseList.class)
@@ -53,13 +55,7 @@ public class CourseController {
             return authorized;
         }
 
-        long idI = -1;
-        try {
-            idI = Long.parseLong(id);
-        } catch (NumberFormatException e) {
-            log.error(COURSE_ID_NOT_LONG, id);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
+        long idI = Long.parseLong(id);
         Set<Long> s = new HashSet<>();
         s.add(idI);
         Collection<User> users = userRepository.findAllById(s);
@@ -80,14 +76,7 @@ public class CourseController {
             return authorized;
         }
 
-        long idI = -1;
-        try {
-            idI = Long.parseLong(id);
-        } catch (NumberFormatException e) {
-            log.error(COURSE_ID_NOT_LONG, id);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-        Course course = courseRepository.findById(idI).orElse(null);
+        Course course = courseRepository.findById(Long.parseLong(id)).orElse(null);
         return new ResponseEntity<>(course, HttpStatus.OK);
     }
 
@@ -138,11 +127,7 @@ public class CourseController {
         }
 
         Course c = courseRepository.findById(courseDto.getId()).orElse(null);
-        if (c == null) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        }
-
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
         if (teacherAuthorized != null) {
             return teacherAuthorized;
         }
@@ -173,20 +158,8 @@ public class CourseController {
             return authorized;
         }
 
-        long idCourse = -1;
-        try {
-            idCourse = Long.parseLong(courseId);
-        } catch (NumberFormatException e) {
-            log.error(COURSE_ID_NOT_LONG, courseId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-        if (c == null) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        }
-
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
         if (teacherAuthorized != null) {
             return teacherAuthorized;
         }
@@ -212,20 +185,8 @@ public class CourseController {
             return authorized;
         }
 
-        long idCourse = -1;
-        try {
-            idCourse = Long.parseLong(courseId);
-        } catch (NumberFormatException e) {
-            log.error(COURSE_ID_NOT_LONG, courseId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-        if (c == null) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        }
-
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
         if (teacherAuthorized != null) {
             return teacherAuthorized;
         }
@@ -243,27 +204,11 @@ public class CourseController {
             (emailValidator.isValid(attenderEmail) ? attenderEmailsValid : attenderEmailsInvalid).add(attenderEmail);
         }
 
-        Collection<User> newPossibleAttenders = userRepository.findByNameIn(attenderEmailsValid);
-        Collection<User> newAddedAttenders = new HashSet<>();
-        Collection<User> alreadyAddedAttenders = new HashSet<>();
-
-        for (String s : attenderEmailsValid) {
-            if (!this.userListContainsEmail(newPossibleAttenders, s)) {
-                attenderEmailsNotRegistered.add(s);
-            }
-        }
-
-        for (User attender : newPossibleAttenders) {
-            (updateAttenderCourseRelationship(c, attender) ? newAddedAttenders : alreadyAddedAttenders).add(attender);
-        }
-
-        //Saving the attenders (all of them, just in case a field of the bidirectional relationship is missing in a Course or a User)
-        userRepository.saveAll(newPossibleAttenders);
-        //Saving the modified course
-        courseRepository.save(c);
+        CourseAttenderService.AttenderUpdateResult result =
+                courseAttenderService.updateAttenders(c, attenderEmailsValid, attenderEmailsNotRegistered);
 
         AddAttendersResponse customResponse = new AddAttendersResponse(
-                newAddedAttenders, alreadyAddedAttenders, attenderEmailsInvalid, attenderEmailsNotRegistered);
+                result.added(), result.alreadyAdded(), attenderEmailsInvalid, attenderEmailsNotRegistered);
 
         if (log.isInfoEnabled()) {
             log.info("Attenders added: {} | Attenders already exist: {} | Emails not valid: {} | Emails valid but no registered: {}",
@@ -287,11 +232,7 @@ public class CourseController {
         }
 
         Course c = courseRepository.findById(courseDto.getId()).orElse(null);
-        if (c == null) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        }
-
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
         if (teacherAuthorized != null) {
             return teacherAuthorized;
         }
@@ -307,31 +248,6 @@ public class CourseController {
         //Saving the modified course
         courseRepository.save(c);
         return new ResponseEntity<>(c.getAttenders(), HttpStatus.OK);
-    }
-
-    private boolean updateAttenderCourseRelationship(Course c, User attender) {
-        boolean isNew = true;
-        if (!attender.getCourses().contains(c)) {
-            attender.getCourses().add(c);
-        } else {
-            isNew = false;
-        }
-        if (!c.getAttenders().contains(attender)) {
-            c.getAttenders().add(attender);
-        } else {
-            isNew = false;
-        }
-        return isNew;
-    }
-
-    //Checks if a User collection contains a user with certain email
-    private boolean userListContainsEmail(Collection<User> users, String email) {
-        for (User u : users) {
-            if (u.getName().equals(email)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private record AddAttendersResponse(Collection<User> attendersAdded, Collection<User> attendersAlreadyAdded,

--- a/sut/src/main/java/com/fullteaching/backend/course/CourseDto.java
+++ b/sut/src/main/java/com/fullteaching/backend/course/CourseDto.java
@@ -1,44 +1,19 @@
 package com.fullteaching.backend.course;
 
+import com.fullteaching.backend.IdRef;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class CourseDto {
+public class CourseDto extends AbstractCourseData {
 
-    private long id;
-    private String title;
-    private String image;
     private CourseDetailsRef courseDetails;
-    private Set<UserRef> attenders;
+    private Set<IdRef> attenders;
 
     public CourseDto() {
         // Required by Jackson for deserialization
-    }
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getImage() {
-        return image;
-    }
-
-    public void setImage(String image) {
-        this.image = image;
     }
 
     public CourseDetailsRef getCourseDetails() {
@@ -49,18 +24,18 @@ public class CourseDto {
         this.courseDetails = courseDetails;
     }
 
-    public Set<UserRef> getAttenders() {
+    public Set<IdRef> getAttenders() {
         return attenders;
     }
 
-    public void setAttenders(Set<UserRef> attenders) {
+    public void setAttenders(Set<IdRef> attenders) {
         this.attenders = attenders;
     }
 
     /** Returns the IDs of all attenders, or an empty set if none were sent. */
     public Set<Long> getAttenderIds() {
         if (attenders == null) return Collections.emptySet();
-        return attenders.stream().map(UserRef::getId).collect(Collectors.toCollection(HashSet::new));
+        return attenders.stream().map(IdRef::getId).collect(Collectors.toCollection(HashSet::new));
     }
 
     /** Captures id, info, and forum.activated from the nested courseDetails object in the JSON. */
@@ -104,24 +79,6 @@ public class CourseDto {
             public void setActivated(boolean activated) {
                 this.activated = activated;
             }
-        }
-    }
-
-    /** Captures only the id from each attender object in the JSON. */
-    public static class UserRef {
-
-        private long id;
-
-        public UserRef() {
-            // Required by Jackson for deserialization
-        }
-
-        public long getId() {
-            return id;
-        }
-
-        public void setId(long id) {
-            this.id = id;
         }
     }
 }

--- a/sut/src/main/java/com/fullteaching/backend/entry/EntryController.java
+++ b/sut/src/main/java/com/fullteaching/backend/entry/EntryController.java
@@ -50,15 +50,7 @@ public class EntryController {
             return authorized;
         }
 
-        long idI = -1;
-        try {
-            idI = Long.parseLong(forumId);
-        } catch (NumberFormatException e) {
-            log.error("Forum ID '{}' is not of type Long", forumId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Forum forum = forumRepository.findById(idI).orElse(null);
+        Forum forum = forumRepository.findById(Long.parseLong(forumId)).orElse(null);
         if (forum == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/sut/src/main/java/com/fullteaching/backend/file/File.java
+++ b/sut/src/main/java/com/fullteaching/backend/file/File.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.security.SecureRandom;
+
 @Entity
 public class File {
 
@@ -22,6 +24,8 @@ public class File {
     private String link;
 
     private int indexOrder;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public File() {
     }
@@ -115,7 +119,7 @@ public class File {
 
     //Generates a string which acts as an identifier for the stored file in the system (local, S3...)
     private String generateNameIdent(String originalName) {
-        String s = originalName + (Math.random() * (Integer.MIN_VALUE - Integer.MAX_VALUE));
+        String s = originalName + SECURE_RANDOM.nextLong();
         s = new BCryptPasswordEncoder().encode(s);
         if (s == null) {
             s = "";

--- a/sut/src/main/java/com/fullteaching/backend/file/FileController.java
+++ b/sut/src/main/java/com/fullteaching/backend/file/FileController.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StreamUtils;
@@ -54,8 +53,6 @@ public class FileController {
     private final AuthorizationService authorizationService;
     private final FileOperationsService fileOperationsService;
     private static final String HTTPS_PROTOCOL = "https://";
-    @Value("${profile.stage}")
-    private String profileStage;
 
     @Autowired
     public FileController(FileOperationsService fileOpServ, ObjectProvider<UserComponent> userComp, AuthorizationService authServ, UserRepository userRep, CommentRepository commentRepo, CourseRepository courseRepo, FileRepository fileRepo, FileGroupRepository fileGroupRepo) {
@@ -81,17 +78,8 @@ public class FileController {
             return authorized;
         }
 
-        long idCourse;
-        long idFileGroup;
-        try {
-            idCourse = Long.parseLong(courseId);
-            idFileGroup = Long.parseLong(fileGroupId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' or FileGroup ID '{}' are not of type Long", courseId, fileGroupId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
+        long idFileGroup = Long.parseLong(fileGroupId);
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
         if (c == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
@@ -115,7 +103,7 @@ public class FileController {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
         fileGroupRepository.save(fg);
-        return new ResponseEntity<>(this.getRootFileGroup(fg), HttpStatus.CREATED);
+        return new ResponseEntity<>(fg.findRoot(), HttpStatus.CREATED);
     }
 
     private FileGroup processUploadedFile(MultipartFile file, long idFileGroup) throws IOException {
@@ -138,7 +126,7 @@ public class FileController {
         File uploadedFile = new File(FILES_FOLDER.toFile(), customFile.getNameIdent());
         file.transferTo(uploadedFile);
 
-        if (this.isProductionStage()) {
+        if (fileOperationsService.isProductionStage()) {
             saveFileProduction(customFile, uploadedFile);
         } else {
             customFile.setLink(uploadedFile.getPath());
@@ -179,18 +167,8 @@ public class FileController {
             return;
         }
 
-        long idCourse;
-        long idFile;
-        try {
-            idCourse = Long.parseLong(courseId);
-            idFile = Long.parseLong(fileId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' or File ID '{}' are not of type Long", courseId, fileId);
-            response.sendError(422, "Invalid format");
-            return;
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
+        long idFile = Long.parseLong(fileId);
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
         if (c == null) {
             response.sendError(404, "Course not found");
             return;
@@ -209,7 +187,7 @@ public class FileController {
 
         log.info(LOG_FILE_NAME, f.getName());
 
-        if (this.isProductionStage()) {
+        if (fileOperationsService.isProductionStage()) {
             fileOperationsService.productionFileDownloader(f.getNameIdent(), response);
         } else {
             downloadFileDev(f, response);
@@ -244,15 +222,7 @@ public class FileController {
             return authorized;
         }
 
-        long idUser;
-        try {
-            idUser = Long.parseLong(userId);
-        } catch (NumberFormatException e) {
-            log.error("User ID '{}' is not of type Long", userId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        User u = userRepository.findById(idUser).orElse(null);
+        User u = userRepository.findById(Long.parseLong(userId)).orElse(null);
 
         ResponseEntity<Object> userAuthorized = authorizationService.checkAuthorization(u, this.userProvider.getObject().getLoggedUser());
         if (userAuthorized != null) {
@@ -291,7 +261,7 @@ public class FileController {
         File uploadedPicture = new File(PICTURES_FOLDER.toFile(), encodedName);
         file.transferTo(uploadedPicture);
 
-        if (this.isProductionStage()) {
+        if (fileOperationsService.isProductionStage()) {
             savePictureProduction(encodedName, uploadedPicture, u);
         } else {
             savePictureDevelopment(uploadedPicture, u);
@@ -336,17 +306,8 @@ public class FileController {
             return authorized;
         }
 
-        long idCourse;
-        long idComment;
-        try {
-            idCourse = Long.parseLong(courseId);
-            idComment = Long.parseLong(commentId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' or Comment ID '{}' are not of type Long", courseId, commentId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
+        long idComment = Long.parseLong(commentId);
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
         if (c == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
@@ -400,7 +361,7 @@ public class FileController {
         File uploadedFile = new File(VIDEOS_FOLDER.toFile(), finalName);
         file.transferTo(uploadedFile);
 
-        if (this.isProductionStage()) {
+        if (fileOperationsService.isProductionStage()) {
             saveVideoProduction(finalName, uploadedFile, comment);
         } else {
             saveVideoDevelopment(finalName, courseId, comment);
@@ -422,18 +383,6 @@ public class FileController {
 
     private void saveVideoDevelopment(String finalName, String courseId, Comment comment) {
         comment.setVideourl("/assets/videos/" + courseId + "/" + finalName);
-    }
-
-    // Method to get the root FileGroup of a FileGroup tree structure, given a FileGroup
-    private FileGroup getRootFileGroup(FileGroup fg) {
-        while (fg.getFileGroupParent() != null) {
-            fg = fg.getFileGroupParent();
-        }
-        return fg;
-    }
-
-    private boolean isProductionStage() {
-        return this.profileStage.equals("prod");
     }
 
 }

--- a/sut/src/main/java/com/fullteaching/backend/file/FileOperationsService.java
+++ b/sut/src/main/java/com/fullteaching/backend/file/FileOperationsService.java
@@ -24,12 +24,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.*;
+import java.security.SecureRandom;
 import java.util.List;
 
 @Service
 public class FileOperationsService {
 
     private static final Logger log = LoggerFactory.getLogger(FileOperationsService.class);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private static final String LOG_ERROR_MESSAGE    = "Error Message:    {}";
     private static final String LOG_HTTP_STATUS_CODE = "HTTP Status Code: {}";
@@ -198,7 +200,7 @@ public class FileOperationsService {
         // Getting the image extension, discarding any path-like characters it may contain
         String picExtension = this.getFileExtension(originalFileName).replaceAll("[^A-Za-z0-9]", "");
         // Appending a random integer to the name
-        originalFileName += (Math.random() * (Integer.MIN_VALUE - Integer.MAX_VALUE));
+        originalFileName += SECURE_RANDOM.nextLong();
         // Encoding original file name + random integer
         originalFileName = new BCryptPasswordEncoder().encode(originalFileName);
         if (originalFileName == null) {

--- a/sut/src/main/java/com/fullteaching/backend/file/FileOperationsService.java
+++ b/sut/src/main/java/com/fullteaching/backend/file/FileOperationsService.java
@@ -45,9 +45,16 @@ public class FileOperationsService {
     @Value("${aws.namecard.bucket}")
     private String bucketAWS;
 
+    @Value("${profile.stage}")
+    private String profileStage;
+
     @Autowired(required = false)
     public FileOperationsService(AmazonS3 amazonS3) {
         this.amazonS3 = amazonS3;
+    }
+
+    public boolean isProductionStage() {
+        return "prod".equals(profileStage);
     }
 
     public String getBucketAWS() {
@@ -59,8 +66,6 @@ public class FileOperationsService {
         if (log.isInfoEnabled()) {
             log.info("Deleting local temp file '{}'", LogSanitizer.sanitize(path));
         }
-        // Deleting stored file...
-
         Path o1 = Paths.get(folder.toString());
         try {
             Files.delete(path);
@@ -72,7 +77,6 @@ public class FileOperationsService {
         } catch (DirectoryNotEmptyException x) {
             log.error("Directory '{}' not empty", o1);
         } catch (IOException x) {
-            // File permission problems are caught here
             log.error("Permission error: {}", x.toString());
         }
     }
@@ -84,15 +88,9 @@ public class FileOperationsService {
             amazonS3.deleteObject(new DeleteObjectRequest(bucketName, fileName));
             log.info("S3 DELETION: File '{}' successfully deleted", fileName);
         } catch (AmazonServiceException ase) {
-            log.info("Caught an AmazonServiceException.");
-            log.info(LOG_ERROR_MESSAGE, ase.getMessage());
-            log.info(LOG_HTTP_STATUS_CODE, ase.getStatusCode());
-            log.info(LOG_AWS_ERROR_CODE, ase.getErrorCode());
-            log.info(LOG_ERROR_TYPE, ase.getErrorType());
-            log.info(LOG_REQUEST_ID, ase.getRequestId());
+            logAmazonServiceException(ase);
         } catch (AmazonClientException ace) {
-            log.info("Caught an AmazonClientException.");
-            log.info(LOG_CLIENT_ERROR_MSG, ace.getMessage());
+            logAmazonClientException(ace);
         }
     }
 
@@ -122,15 +120,11 @@ public class FileOperationsService {
     }
 
     public void productionFileSaver(String keyName, String folderName, File f) throws InterruptedException {
-
         log.info("Uploading an object to S3");
-
         String bucketName = bucketAWS + "/" + folderName;
         TransferManager tm = TransferManagerBuilder.standard().withS3Client(amazonS3).build();
-        // TransferManager processes all transfers asynchronously, so this call will return immediately
         Upload upload = tm.upload(bucketName, keyName, f);
         try {
-            // Or you can block and wait for the upload to finish
             upload.waitForCompletion();
             log.info("Upload completed");
         } catch (AmazonClientException amazonClientException) {
@@ -154,14 +148,10 @@ public class FileOperationsService {
 
         } catch (AmazonServiceException ase) {
             log.error("Caught an AmazonServiceException, which means your request made it to Amazon S3, but was rejected with an error response for some reason.");
-            log.error(LOG_ERROR_MESSAGE, ase.getMessage());
-            log.error(LOG_HTTP_STATUS_CODE, ase.getStatusCode());
-            log.error(LOG_AWS_ERROR_CODE, ase.getErrorCode());
-            log.error(LOG_ERROR_TYPE, ase.getErrorType());
-            log.error(LOG_REQUEST_ID, ase.getRequestId());
+            logAmazonServiceException(ase);
         } catch (AmazonClientException ace) {
             log.error("Caught an AmazonClientException, which means the client encountered an internal error while trying to communicate with S3, such as not being able to access the network.");
-            log.error(LOG_CLIENT_ERROR_MSG, ace.getMessage());
+            logAmazonClientException(ace);
         } catch (IOException ex) {
             throw new IOException("IOError writing file to output stream");
         }
@@ -173,15 +163,9 @@ public class FileOperationsService {
             amazonS3.deleteObject(new DeleteObjectRequest(bucketName, fileName));
             log.info("S3 DELETION: File '{}' deleted successfully", fileName);
         } catch (AmazonServiceException ase) {
-            log.error("Caught an AmazonServiceException.");
-            log.error(LOG_ERROR_MESSAGE, ase.getMessage());
-            log.error(LOG_HTTP_STATUS_CODE, ase.getStatusCode());
-            log.error(LOG_AWS_ERROR_CODE, ase.getErrorCode());
-            log.error(LOG_ERROR_TYPE, ase.getErrorType());
-            log.error(LOG_REQUEST_ID, ase.getRequestId());
+            logAmazonServiceException(ase);
         } catch (AmazonClientException ace) {
-            log.error("Caught an AmazonClientException.");
-            log.error(LOG_CLIENT_ERROR_MSG, ace.getMessage());
+            logAmazonClientException(ace);
         }
     }
 
@@ -197,20 +181,29 @@ public class FileOperationsService {
         if (originalFileName == null) {
             originalFileName = "";
         }
-        // Getting the image extension, discarding any path-like characters it may contain
         String picExtension = this.getFileExtension(originalFileName).replaceAll("[^A-Za-z0-9]", "");
-        // Appending a random integer to the name
         originalFileName += SECURE_RANDOM.nextLong();
-        // Encoding original file name + random integer
         originalFileName = new BCryptPasswordEncoder().encode(originalFileName);
         if (originalFileName == null) {
             originalFileName = "";
         }
-        // Deleting all non-alphanumeric characters
         originalFileName = originalFileName.replaceAll("[^A-Za-z0-9\\$]", "");
-        // Adding the extension
         originalFileName += "." + picExtension;
         return originalFileName;
+    }
+
+    private void logAmazonServiceException(AmazonServiceException ase) {
+        log.error("Caught an AmazonServiceException.");
+        log.error(LOG_ERROR_MESSAGE, ase.getMessage());
+        log.error(LOG_HTTP_STATUS_CODE, ase.getStatusCode());
+        log.error(LOG_AWS_ERROR_CODE, ase.getErrorCode());
+        log.error(LOG_ERROR_TYPE, ase.getErrorType());
+        log.error(LOG_REQUEST_ID, ase.getRequestId());
+    }
+
+    private void logAmazonClientException(AmazonClientException ace) {
+        log.error("Caught an AmazonClientException.");
+        log.error(LOG_CLIENT_ERROR_MSG, ace.getMessage());
     }
 
 }

--- a/sut/src/main/java/com/fullteaching/backend/file/MultipartFileSender.java
+++ b/sut/src/main/java/com/fullteaching/backend/file/MultipartFileSender.java
@@ -315,15 +315,11 @@ public class MultipartFileSender {
          */
         public static boolean accepts(String acceptHeader, String toAccept) {
             if (acceptHeader == null || toAccept == null) return false;
-
-            // 1. Split using a non-backtracking regex or simple split
-            // Using \s*+ to be possessive and prevent ReDoS
-            String[] parts = acceptHeader.split("\\s*+[,;]\\s*+");
-
-            // 2. Use a Set for O(1) lookups instead of sorting/binary search
-            Set<String> acceptValues = new HashSet<>(Arrays.asList(parts));
-
-            // 3. Check specific conditions
+            String[] parts = acceptHeader.split("[,;]");
+            Set<String> acceptValues = new HashSet<>();
+            for (String part : parts) {
+                acceptValues.add(part.strip());
+            }
             return acceptValues.contains(toAccept)
                     || acceptValues.contains(toAccept.replaceAll("/.*$", "/*"))
                     || acceptValues.contains("*/*");
@@ -337,7 +333,10 @@ public class MultipartFileSender {
          * @return True if the given match header matches the given value.
          */
         public static boolean matches(String matchHeader, String toMatch) {
-            String[] matchValues = matchHeader.split("\\s*,\\s*");
+            String[] matchValues = matchHeader.split(",");
+            for (int i = 0; i < matchValues.length; i++) {
+                matchValues[i] = matchValues[i].strip();
+            }
             Arrays.sort(matchValues);
             return Arrays.binarySearch(matchValues, toMatch) > -1 || Arrays.binarySearch(matchValues, "*") > -1;
         }

--- a/sut/src/main/java/com/fullteaching/backend/filegroup/FileGroup.java
+++ b/sut/src/main/java/com/fullteaching/backend/filegroup/FileGroup.java
@@ -34,10 +34,7 @@ public class FileGroup {
     }
 
     public FileGroup(String title) {
-        this.title = title;
-        this.files = new ArrayList<>();
-        this.fileGroups = new ArrayList<>();
-        this.fileGroupParent = null;
+        this(title, null);
     }
 
     public FileGroup(String title, FileGroup fileGroupParent) {
@@ -99,6 +96,15 @@ public class FileGroup {
     @Override
     public int hashCode() {
         return Long.hashCode(id);
+    }
+
+    /** Returns the root ancestor of this FileGroup tree (itself if already root). */
+    public FileGroup findRoot() {
+        FileGroup current = this;
+        while (current.getFileGroupParent() != null) {
+            current = current.getFileGroupParent();
+        }
+        return current;
     }
 
     public void updateFileIndexOrder() {

--- a/sut/src/main/java/com/fullteaching/backend/filegroup/FileGroupController.java
+++ b/sut/src/main/java/com/fullteaching/backend/filegroup/FileGroupController.java
@@ -14,7 +14,6 @@ import com.fullteaching.backend.util.LogSanitizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,9 +33,6 @@ public class FileGroupController {
     private final CourseDetailsRepository courseDetailsRepository;
     private final AuthorizationService authorizationService;
     private final FileOperationsService fileOperationsService;
-
-    @Value("${profile.stage}")
-    private String profileStage;
 
     @Autowired
     public FileGroupController(FileOperationsService fileOperationsServ, AuthorizationService authServ, CourseDetailsRepository courseDetRepo, CourseRepository courseRepo, FileRepository fileRepo, FileGroupRepository fileGroupRepo) {
@@ -58,14 +54,7 @@ public class FileGroupController {
             return authorized;
         }
 
-        long idI = -1;
-        try {
-            idI = Long.parseLong(courseDetailsId);
-        } catch (NumberFormatException e) {
-            log.error("CourseDetails ID '{}' is not of type Long", courseDetailsId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
+        long idI = Long.parseLong(courseDetailsId);
         CourseDetails cd = courseDetailsRepository.findById(idI).orElse(null);
 
         assert cd != null;
@@ -130,40 +119,22 @@ public class FileGroupController {
             return authorized;
         }
 
-        long idCourse = -1;
-        try {
-            idCourse = Long.parseLong(courseId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' is not of type Long", courseId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-
-        assert c != null;
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
-        if (teacherAuthorized != null) { // If the user is not the teacher of the course
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
+        if (teacherAuthorized != null) {
             return teacherAuthorized;
-        } else {
-
-            FileGroup fg = fileGroupRepository.findById(fileGroupDto.getId()).orElse(null);
-
-            if (fg != null) {
-
-                log.info("Updating filegroup. Previous value: {}", fg);
-
-                fg.setTitle(fileGroupDto.getTitle());
-                fileGroupRepository.save(fg);
-
-                log.info("FileGroup succesfully updated. Modified value: {}", fg);
-
-                //Returning the root FileGroup of the added file
-                return new ResponseEntity<>(this.getRootFileGroup(fg), HttpStatus.OK);
-            } else {
-                log.error("FileGroup with id '{}' doesn't exist", fileGroupDto.getId());
-                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-            }
         }
+
+        FileGroup fg = fileGroupRepository.findById(fileGroupDto.getId()).orElse(null);
+        if (fg != null) {
+            log.info("Updating filegroup. Previous value: {}", fg);
+            fg.setTitle(fileGroupDto.getTitle());
+            fileGroupRepository.save(fg);
+            log.info("FileGroup succesfully updated. Modified value: {}", fg);
+            return new ResponseEntity<>(fg.findRoot(), HttpStatus.OK);
+        }
+        log.error("FileGroup with id '{}' doesn't exist", fileGroupDto.getId());
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
 
@@ -175,37 +146,16 @@ public class FileGroupController {
 
         log.info("CRUD operation: Deleting filegroup");
 
-        ResponseEntity<Object> authorized = authorizationService.checkBackendLogged();
-        if (authorized != null) {
-            return authorized;
-        }
-
-        long idFileGroup = -1;
-        long idCourse = -1;
-        try {
-            idFileGroup = Long.parseLong(fileGroupId);
-            idCourse = Long.parseLong(courseId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' or FileGroup ID '{}' are not of type Long", courseId, fileGroupId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-
-        assert c != null;
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
-        if (teacherAuthorized != null) { // If the user is not the teacher of the course
-            return teacherAuthorized;
-        }
-
-        FileGroup fg = fileGroupRepository.findById(idFileGroup).orElse(null);
+        FileGroupAuth auth = authorizeAndFetchGroup(fileGroupId, courseId);
+        if (auth.error() != null) return auth.error();
+        Course c = auth.course();
+        FileGroup fg = auth.fileGroup();
 
         if (fg != null) {
 
             log.info("Deleting filegroup: {}", fg);
 
-            if (this.isProductionStage()) {
+            if (fileOperationsService.isProductionStage()) {
                 //Removing all the S3 stored files of the tree structure...
                 for (File f : fg.getFiles()) {
                     fileOperationsService.deleteRemoteFile(f.getNameIdent(), "/files");
@@ -250,55 +200,35 @@ public class FileGroupController {
             return authorized;
         }
 
-        long idCourse = -1;
-        long idFile = -1;
-        long idSource = -1;
-        long idTarget = -1;
-        int pos = 0;
-        try {
-            idCourse = Long.parseLong(courseId);
-            idFile = Long.parseLong(fileId);
-            idSource = Long.parseLong(sourceId);
-            idTarget = Long.parseLong(targetId);
-            pos = Integer.parseInt(position);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' or File ID '{}' or source ID '{}' or target ID '{}' are not of type Long; or position {} is not of type Integer",
-                    courseId, fileId, sourceId, targetId, pos);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-
-        assert c != null;
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
-        if (teacherAuthorized != null) { // If the user is not the teacher of the course
+        long idFile = Long.parseLong(fileId);
+        long idSource = Long.parseLong(sourceId);
+        long idTarget = Long.parseLong(targetId);
+        int pos = Integer.parseInt(position);
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
+        if (teacherAuthorized != null) {
             return teacherAuthorized;
-        } else {
-
-            FileGroup sourceFg = fileGroupRepository.findById(idSource).orElse(null);
-            FileGroup targetFg = fileGroupRepository.findById(idTarget).orElse(null);
-            File fileMoved = fileRepository.findById(idFile).orElse(null);
-
-            log.info("Moving file {} from filegroup {} to filegroup {} into position {}", fileMoved, sourceFg, targetFg, pos);
-
-            assert sourceFg != null;
-            assert targetFg != null;
-            sourceFg.getFiles().remove(fileMoved);
-            targetFg.getFiles().add(pos, fileMoved);
-
-            sourceFg.updateFileIndexOrder();
-            targetFg.updateFileIndexOrder();
-
-            List<FileGroup> l = new ArrayList<>();
-            l.add(sourceFg);
-            l.add(targetFg);
-            fileGroupRepository.saveAll(l);
-
-            log.info("File order succesfully updated");
-
-            //Returning the FileGroups of the course
-            return new ResponseEntity<>(c.getCourseDetails().getFiles(), HttpStatus.OK);
         }
+
+        FileGroup sourceFg = fileGroupRepository.findById(idSource).orElse(null);
+        FileGroup targetFg = fileGroupRepository.findById(idTarget).orElse(null);
+        File fileMoved = fileRepository.findById(idFile).orElse(null);
+
+        log.info("Moving file {} from filegroup {} to filegroup {} into position {}", fileMoved, sourceFg, targetFg, pos);
+
+        assert sourceFg != null;
+        assert targetFg != null;
+        sourceFg.getFiles().remove(fileMoved);
+        targetFg.getFiles().add(pos, fileMoved);
+
+        sourceFg.updateFileIndexOrder();
+        targetFg.updateFileIndexOrder();
+
+        fileGroupRepository.saveAll(List.of(sourceFg, targetFg));
+
+        log.info("File order succesfully updated");
+
+        return new ResponseEntity<>(c.getCourseDetails().getFiles(), HttpStatus.OK);
     }
 
 
@@ -310,53 +240,24 @@ public class FileGroupController {
 
         log.info("CRUD operation: Updating file");
 
-        ResponseEntity<Object> authorized = authorizationService.checkBackendLogged();
-        if (authorized != null) {
-            return authorized;
-        }
-
-        long idFileGroup = -1;
-        long idCourse = -1;
-        try {
-            idFileGroup = Long.parseLong(fileGroupId);
-            idCourse = Long.parseLong(courseId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' or FileGroup ID '{}' are not of type Long", courseId, fileGroupId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-
-        assert c != null;
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
-        if (teacherAuthorized != null) { // If the user is not the teacher of the course
-            return teacherAuthorized;
-        } else {
-
-            FileGroup fg = fileGroupRepository.findById(idFileGroup).orElse(null);
-
-            if (fg != null) {
-                for (int i = 0; i < fg.getFiles().size(); i++) {
-                    if (fg.getFiles().get(i).getId() == fileDto.getId()) {
-
-                        log.info("Updating file. Previous value: {}", fg.getFiles().get(i));
-
-                        fg.getFiles().get(i).setName(fileDto.getName());
-                        fileGroupRepository.save(fg);
-
-                        log.info("File succesfully updated. Modified value: {}", fg.getFiles().get(i));
-
-                        //Returning the root FileGroup of the added file
-                        return new ResponseEntity<>(this.getRootFileGroup(fg), HttpStatus.OK);
-                    }
+        FileGroupAuth auth = authorizeAndFetchGroup(fileGroupId, courseId);
+        if (auth.error() != null) return auth.error();
+        FileGroup fg = auth.fileGroup();
+        if (fg != null) {
+            for (int i = 0; i < fg.getFiles().size(); i++) {
+                if (fg.getFiles().get(i).getId() == fileDto.getId()) {
+                    log.info("Updating file. Previous value: {}", fg.getFiles().get(i));
+                    fg.getFiles().get(i).setName(fileDto.getName());
+                    fileGroupRepository.save(fg);
+                    log.info("File succesfully updated. Modified value: {}", fg.getFiles().get(i));
+                    return new ResponseEntity<>(fg.findRoot(), HttpStatus.OK);
                 }
-
-                log.error("File not found");
-            } else {
-                log.error("FileGroup not found");
             }
-            return new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
+            log.error("File not found");
+        } else {
+            log.error("FileGroup not found");
         }
+        return new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
     }
 
 
@@ -374,23 +275,11 @@ public class FileGroupController {
             return authorized;
         }
 
-        long idFile = -1;
-        long idFileGroup = -1;
-        long idCourse = -1;
-        try {
-            idFile = Long.parseLong(fileId);
-            idFileGroup = Long.parseLong(fileGroupId);
-            idCourse = Long.parseLong(courseId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' or FileGroup ID '{}' or File ID '{}' are not of type Long", courseId, fileGroupId, fileId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-
-        assert c != null;
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
-        if (teacherAuthorized != null) { // If the user is not the teacher of the course
+        long idFile = Long.parseLong(fileId);
+        long idFileGroup = Long.parseLong(fileGroupId);
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
+        if (teacherAuthorized != null) {
             return teacherAuthorized;
         }
 
@@ -402,7 +291,7 @@ public class FileGroupController {
 
                 log.info("Deleting file: {}", file);
 
-                if (this.isProductionStage()) {
+                if (fileOperationsService.isProductionStage()) {
                     //ONLY ON PRODUCTION
                     //Deleting S3 stored file...
                     fileOperationsService.deleteRemoteFile(file.getNameIdent(), "/files");
@@ -435,6 +324,21 @@ public class FileGroupController {
         }
     }
 
+    private record FileGroupAuth(ResponseEntity<Object> error, Course course, FileGroup fileGroup) {}
+
+    /** Combines login check, teacher authorization and FileGroup fetch for course/{courseId} endpoints. */
+    private FileGroupAuth authorizeAndFetchGroup(String fileGroupId, String courseId) {
+        ResponseEntity<Object> logged = authorizationService.checkBackendLogged();
+        if (logged != null) return new FileGroupAuth(logged, null, null);
+
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
+        ResponseEntity<Object> authz = authorizationService.checkTeacherAuthorization(c);
+        if (authz != null) return new FileGroupAuth(authz, null, null);
+
+        FileGroup fg = fileGroupRepository.findById(Long.parseLong(fileGroupId)).orElse(null);
+        return new FileGroupAuth(null, c, fg);
+    }
+
     private File findFileInGroup(FileGroup fg, long idFile) {
         for (File f : fg.getFiles()) {
             if (f.getId() == idFile) {
@@ -442,18 +346,6 @@ public class FileGroupController {
             }
         }
         return null;
-    }
-
-    //Method to get the root FileGroup of a FileGroup tree structure, given a FileGroup
-    private FileGroup getRootFileGroup(FileGroup fg) {
-        while (fg.getFileGroupParent() != null) {
-            fg = fg.getFileGroupParent();
-        }
-        return fg;
-    }
-
-    private boolean isProductionStage() {
-        return this.profileStage.equals("prod");
     }
 
 }

--- a/sut/src/main/java/com/fullteaching/backend/filegroup/FileGroupDto.java
+++ b/sut/src/main/java/com/fullteaching/backend/filegroup/FileGroupDto.java
@@ -1,10 +1,12 @@
 package com.fullteaching.backend.filegroup;
 
+import com.fullteaching.backend.IdRef;
+
 public class FileGroupDto {
 
     private long id;
     private String title;
-    private FileGroupParentRef fileGroupParent;
+    private IdRef fileGroupParent;
 
     public FileGroupDto() {
         // Required by Jackson for deserialization
@@ -26,34 +28,16 @@ public class FileGroupDto {
         this.title = title;
     }
 
-    public FileGroupParentRef getFileGroupParent() {
+    public IdRef getFileGroupParent() {
         return fileGroupParent;
     }
 
-    public void setFileGroupParent(FileGroupParentRef fileGroupParent) {
+    public void setFileGroupParent(IdRef fileGroupParent) {
         this.fileGroupParent = fileGroupParent;
     }
 
     /** Returns the parent's ID, or null if this is a root FileGroup. */
     public Long getFileGroupParentId() {
         return fileGroupParent != null ? fileGroupParent.getId() : null;
-    }
-
-    /** Captures only the id from the nested fileGroupParent object in the JSON. */
-    public static class FileGroupParentRef {
-
-        private long id;
-
-        public FileGroupParentRef() {
-            // Required by Jackson for deserialization
-        }
-
-        public long getId() {
-            return id;
-        }
-
-        public void setId(long id) {
-            this.id = id;
-        }
     }
 }

--- a/sut/src/main/java/com/fullteaching/backend/filereader/FileReaderController.java
+++ b/sut/src/main/java/com/fullteaching/backend/filereader/FileReaderController.java
@@ -1,12 +1,12 @@
 package com.fullteaching.backend.filereader;
 
 import com.fullteaching.backend.course.Course;
+import com.fullteaching.backend.course.CourseAttenderService;
 import com.fullteaching.backend.course.CourseRepository;
 import com.fullteaching.backend.file.FileController;
 import com.fullteaching.backend.file.FileOperationsService;
 import com.fullteaching.backend.security.AuthorizationService;
 import com.fullteaching.backend.user.User;
-import com.fullteaching.backend.user.UserRepository;
 import com.fullteaching.backend.util.LogSanitizer;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.slf4j.Logger;
@@ -31,16 +31,18 @@ public class FileReaderController {
     private final FileReader fileReader = new FileReader();
 
     private final CourseRepository courseRepository;
-    private final UserRepository userRepository;
     private final AuthorizationService authorizationService;
     private final FileOperationsService fileOperationsService;
+    private final CourseAttenderService courseAttenderService;
 
     @Autowired
-    public FileReaderController(CourseRepository courseRepo,UserRepository userRepo,AuthorizationService authService,FileOperationsService fileOpService){
-        this.courseRepository=courseRepo;
-        this.userRepository=userRepo;
-        this.authorizationService=authService;
-        this.fileOperationsService=fileOpService;
+    public FileReaderController(CourseRepository courseRepo,
+                                AuthorizationService authService, FileOperationsService fileOpService,
+                                CourseAttenderService courseAttenderService) {
+        this.courseRepository = courseRepo;
+        this.authorizationService = authService;
+        this.fileOperationsService = fileOpService;
+        this.courseAttenderService = courseAttenderService;
     }
 
     @PostMapping(value = "/upload/course/{courseId}")
@@ -54,21 +56,9 @@ public class FileReaderController {
             return authorized;
         }
 
-        long idCourse = -1;
-        try {
-            idCourse = Long.parseLong(courseId);
-        } catch (NumberFormatException e) {
-            log.error("Course ID '{}' is not of type Long", courseId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course c = courseRepository.findById(idCourse).orElse(null);
-        if (c == null) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        }
-
-        ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(c, c.getTeacher());
-        if (teacherAuthorized != null) { // If the user is not the teacher of the course
+        Course c = courseRepository.findById(Long.parseLong(courseId)).orElse(null);
+        ResponseEntity<Object> teacherAuthorized = authorizationService.checkTeacherAuthorization(c);
+        if (teacherAuthorized != null) {
             return teacherAuthorized;
         }
 
@@ -145,53 +135,15 @@ public class FileReaderController {
             }
         }
 
-        Collection<User> newPossibleAttenders = userRepository.findByNameIn(attenderEmailsValid);
-        Collection<User> newAddedAttenders = new HashSet<>();
-        Collection<User> alreadyAddedAttenders = new HashSet<>();
-
-        for (String email : attenderEmailsValid) {
-            if (!this.userListContainsEmail(newPossibleAttenders, email)) {
-                attenderEmailsNotRegistered.add(email);
-            }
-        }
-
-        for (User attender : newPossibleAttenders) {
-            boolean newAtt = true;
-            if (!attender.getCourses().contains(c))
-                attender.getCourses().add(c);
-            else
-                newAtt = false;
-            if (!c.getAttenders().contains(attender))
-                c.getAttenders().add(attender);
-            else
-                newAtt = false;
-            (newAtt ? newAddedAttenders : alreadyAddedAttenders).add(attender);
-        }
-
-        // Saving the attenders (all of them, just in case a field of the bidirectional
-        // relationship is missing in a Course or a User)
-        userRepository.saveAll(newPossibleAttenders);
-        // Saving the modified course
-        courseRepository.save(c);
+        CourseAttenderService.AttenderUpdateResult result =
+                courseAttenderService.updateAttenders(c, attenderEmailsValid, attenderEmailsNotRegistered);
 
         AddAttendersByFileResponse customResponse = new AddAttendersByFileResponse();
-        customResponse.attendersAdded = newAddedAttenders;
-        customResponse.attendersAlreadyAdded = alreadyAddedAttenders;
+        customResponse.attendersAdded = result.added();
+        customResponse.attendersAlreadyAdded = result.alreadyAdded();
         customResponse.emailsValidNotRegistered = attenderEmailsNotRegistered;
 
         return customResponse;
-    }
-
-    // Checks if a User collection contains a user with certain email
-    private boolean userListContainsEmail(Collection<User> users, String email) {
-        boolean isContained = false;
-        for (User u : users) {
-            if (u.getName().equals(email)) {
-                isContained = true;
-                break;
-            }
-        }
-        return isContained;
     }
 
     private static class AddAttendersByFileResponse {

--- a/sut/src/main/java/com/fullteaching/backend/forum/ForumController.java
+++ b/sut/src/main/java/com/fullteaching/backend/forum/ForumController.java
@@ -35,15 +35,7 @@ public class ForumController {
             return authorized;
         }
 
-        long idI = -1;
-        try {
-            idI = Long.parseLong(courseDetailsId);
-        } catch (NumberFormatException e) {
-            log.error("CourseDetails ID '{}' is not of type Long", courseDetailsId);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        CourseDetails cd = courseDetailsRepository.findById(idI).orElse(null);
+        CourseDetails cd = courseDetailsRepository.findById(Long.parseLong(courseDetailsId)).orElse(null);
         if (cd == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/sut/src/main/java/com/fullteaching/backend/security/AuthorizationService.java
+++ b/sut/src/main/java/com/fullteaching/backend/security/AuthorizationService.java
@@ -1,5 +1,6 @@
 package com.fullteaching.backend.security;
 
+import com.fullteaching.backend.course.Course;
 import com.fullteaching.backend.user.User;
 import com.fullteaching.backend.user.UserComponent;
 import org.slf4j.Logger;
@@ -27,6 +28,11 @@ public class AuthorizationService {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
         return null;
+    }
+
+    /** Checks that the logged user is the teacher of the given course (null course → NOT_FOUND). */
+    public ResponseEntity<Object> checkTeacherAuthorization(Course course) {
+        return checkAuthorization(course, course != null ? course.getTeacher() : null);
     }
 
     // Checks authorization of teacher

--- a/sut/src/main/java/com/fullteaching/backend/session/Session.java
+++ b/sut/src/main/java/com/fullteaching/backend/session/Session.java
@@ -3,7 +3,7 @@ package com.fullteaching.backend.session;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fullteaching.backend.course.Course;
-import com.fullteaching.backend.course.Course.SimpleCourseList;
+import com.fullteaching.backend.course.AbstractCourseData.SimpleCourseList;
 import jakarta.persistence.*;
 
 @Entity

--- a/sut/src/main/java/com/fullteaching/backend/session/SessionController.java
+++ b/sut/src/main/java/com/fullteaching/backend/session/SessionController.java
@@ -38,15 +38,7 @@ public class SessionController {
             return authorized;
         }
 
-        long idI = -1;
-        try {
-            idI = Long.parseLong(id);
-        } catch (NumberFormatException e) {
-            log.error("Session ID '{}' is not of type Long", id);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Course course = courseRepository.findById(idI).orElse(null);
+        Course course = courseRepository.findById(Long.parseLong(id)).orElse(null);
         if (course == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
@@ -116,15 +108,7 @@ public class SessionController {
             return authorized;
         }
 
-        long idI = -1;
-        try {
-            idI = Long.parseLong(id);
-        } catch (NumberFormatException e) {
-            log.error("Session ID '{}' is not of type Long", id);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Session session = sessionRepository.findById(idI).orElse(null);
+        Session session = sessionRepository.findById(Long.parseLong(id)).orElse(null);
         assert session != null;
         ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(session, session.getCourse().getTeacher());
         if (teacherAuthorized != null) { // If the user is not the teacher of the course
@@ -137,7 +121,7 @@ public class SessionController {
                 log.info("Deleting session: {}", session);
 
                 course.getSessions().remove(session);
-                sessionRepository.deleteById(idI);
+                sessionRepository.deleteById(session.getId());
                 courseRepository.save(course);
 
                 log.info("Session successfully deleted");

--- a/sut/src/main/java/com/fullteaching/backend/session/VideoSessionController.java
+++ b/sut/src/main/java/com/fullteaching/backend/session/VideoSessionController.java
@@ -77,15 +77,7 @@ public class VideoSessionController {
             return authorized;
         }
 
-        long idI;
-        try {
-            idI = Long.parseLong(id);
-        } catch (NumberFormatException e) {
-            log.error("Session ID '{}' is not of type Long", id);
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        Session session = sessionRepository.findById(idI).orElse(null);
+        Session session = sessionRepository.findById(Long.parseLong(id)).orElse(null);
         if (session == null) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
@@ -94,12 +86,13 @@ public class VideoSessionController {
         ResponseEntity<Object> teacherAuthorized = authorizationService.checkAuthorization(session,
                 session.getCourse().getTeacher());
 
-        if (this.lessonIdSession.get(idI) == null) { // First user connecting to the session (only the teacher can)
+        long sessionId = session.getId();
+        if (this.lessonIdSession.get(sessionId) == null) { // First user connecting to the session (only the teacher can)
             if (teacherAuthorized != null) {
                 log.error("Error geting OpenVidu sessionId and token: First user must be the teacher of the course");
                 return teacherAuthorized;
             }
-            return handleFirstConnection(idI, responseJson);
+            return handleFirstConnection(sessionId, responseJson);
         } else { // The video session is already created
             ResponseEntity<Object> userAuthorized = authorizationService.checkAuthorizationUsers(session,
                     session.getCourse().getAttenders());
@@ -107,7 +100,7 @@ public class VideoSessionController {
                 log.error("Error geting OpenVidu token: user must be a student of the course");
                 return userAuthorized;
             }
-            return handleSubsequentConnection(idI, teacherAuthorized, responseJson);
+            return handleSubsequentConnection(sessionId, teacherAuthorized, responseJson);
         }
     }
 

--- a/sut/src/test/java/com/fullteaching/backend/integration/file/FileControllerTest.java
+++ b/sut/src/test/java/com/fullteaching/backend/integration/file/FileControllerTest.java
@@ -204,7 +204,7 @@ class FileControllerTest extends AbstractLoggedControllerUnitTest {
             fail("UNAUTHORIZED: //test OK");
         }
 
-        //test BAD_REQUEST UNPROCESSABLE_ENTITY
+        //test BAD_REQUEST (invalid ID format)
         try {
 
             MvcResult result = mvc.perform(get(DOWNLOAD_URI.replace("{courseId}", "" + c.getId()) + "not_a_long")
@@ -214,7 +214,7 @@ class FileControllerTest extends AbstractLoggedControllerUnitTest {
 
             int status = result.getResponse().getStatus();
 
-            int expected = HttpStatus.UNPROCESSABLE_CONTENT.value();
+            int expected = HttpStatus.BAD_REQUEST.value();
 
             String content = result.getResponse().getContentAsString();
             System.out.println(content);
@@ -223,7 +223,7 @@ class FileControllerTest extends AbstractLoggedControllerUnitTest {
 
         } catch (Exception e) {
             log.error("Unexpected exception during test execution", e);
-            fail("UNAUTHORIZED: //test UNPROCESSABLE_CONTENT");
+            fail("Unexpected exception: //test BAD_REQUEST invalid format");
         }
     }
 


### PR DESCRIPTION
This PR  closes #313 by containing the necessary changes to configure the SonarQube analysis. Basically adds:

- The necessary steps in the workflow to execute the tests, calculate the coverage, and trigger and upload the Sonar Scanner
- the sonar-project.properties file with the env variables required.
- The badge in the readme.

Some additional changes:
- Removed 5 code smells reported by Sonar.
- Solved 3.33% of duplications reported by Sonar

This PR requires that #311  will be closed, because it requires the sut folder and the addition of the jacoco plugin in its pom.xml:

```java
	<plugin>
		<groupId>org.jacoco</groupId>
		<artifactId>jacoco-maven-plugin</artifactId>
		<executions>
			<execution>
				<goals>
					<goal>prepare-agent</goal>
				</goals>
			</execution>
			<execution>
				<id>report</id>
				<phase>test</phase>
				<goals>
					<goal>report</goal>
				</goals>
			</execution>
		</executions>
	</plugin>
```