### PR TITLE
Combined dependency updates (2026-06-23)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     permissions: 
       statuses: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
         <junit-jupiter-api.version>6.1.0</junit-jupiter-api.version>
 
-        <selenium-java.version>4.44.0</selenium-java.version>
+        <selenium-java.version>4.45.0</selenium-java.version>
 
         <selema.version>4.1.0</selema.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.14</version>
+                    <version>0.8.15</version>
                     <executions>
                         <execution>
                             <id>pre-unit-test</id>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.jacoco:jacoco-maven-plugin from 0.8.14 to 0.8.15](https://github.com/giis-uniovi/retorch-st-fullteaching/pull/310)
- [Bump org.seleniumhq.selenium:selenium-java from 4.44.0 to 4.45.0](https://github.com/giis-uniovi/retorch-st-fullteaching/pull/315)
- [Bump actions/checkout from 6 to 7](https://github.com/giis-uniovi/retorch-st-fullteaching/pull/314)