### PR TITLE
Modifying build.yml file to avoid Sonar execution in dependabot branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,17 @@ jobs:
       - name: Build E2E test suite
         run: mvn test-compile -U --no-transfer-progress
 
+  sonarqube:
+    needs: [ build ]
+    #if: ${{ false }}  # disable for now
+    #This job fails when comming from a dependabot PR (can't read the sonarqube token for security reasons).
+    #Links to discussions and workaround at: https://github.com/giis-uniovi/samples-giis-template/issues/4
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v7
+
       - name: SonarCloud analysis
         uses: SonarSource/sonarqube-scan-action@v8
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,15 @@ jobs:
           path: sut/target/site/jacoco/
           retention-days: 7
 
+      - name: Save compiled classes for Sonar analysis
+        uses: actions/upload-artifact@v7
+        with:
+          name: sonar-compiled-classes
+          path: |
+            sut/target/classes
+            sut/target/test-classes
+          retention-days: 1
+
       - name: Build E2E test suite
         run: mvn test-compile -U --no-transfer-progress
 
@@ -69,6 +78,18 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v7
+
+      - name: Restore compiled classes from build job
+        uses: actions/download-artifact@v7
+        with:
+          name: sonar-compiled-classes
+          path: sut/target
+
+      - name: Restore JaCoCo coverage report from build job
+        uses: actions/download-artifact@v7
+        with:
+          name: jacoco-report
+          path: sut/target/site/jacoco
 
       - name: SonarCloud analysis
         uses: SonarSource/sonarqube-scan-action@v8


### PR DESCRIPTION
This PR closes #348, #346, #344, #343, #341, and #339 by disabling Sonar execution on the branches created by Dependabot.
The changes provided are a single modification of the build.yml file where the execution of Sonar is moved to an isolated job, cloning the repo, and executing the analysis only if the user is different from dependabot [bot]